### PR TITLE
catalog builder, правки конфига

### DIFF
--- a/services/catalog-builder/cmd/catalog-builder/config.local.toml
+++ b/services/catalog-builder/cmd/catalog-builder/config.local.toml
@@ -12,34 +12,34 @@ strict_schema = false
 [ecosystems]
 
 [ecosystems.apple]
-is_bridge_target = true
-supported_matter_protocols = ["matter-over-wifi", "matter-over-thread"]
-supported_matter_device_types = [] # empty = all types supported
+supports_external_integrations = true
+supported_matter_protocols = ["matter-over-thread"]
+supported_matter_device_types = ["*"]
 
 [ecosystems.google]
-is_bridge_target = true
+supports_external_integrations = true
 supported_matter_protocols = ["matter-over-wifi", "matter-over-thread"]
-supported_matter_device_types = []
+supported_matter_device_types = ["*"]
 
 [ecosystems.yandex]
-is_bridge_target = true
+supports_external_integrations = true
 supported_matter_protocols = ["matter-over-wifi"]
-supported_matter_device_types = ["smart_lamp"]
+supported_matter_device_types = ["smart_lamp", "smart_plug", "smart_switch"]
 
 [ecosystems.sber]
-is_bridge_target = true
+supports_external_integrations = true
 supported_matter_protocols = []
 supported_matter_device_types = []
 
 [ecosystems.vk]
-is_bridge_target = true
+supports_external_integrations = true
 supported_matter_protocols = []
 supported_matter_device_types = []
 
 [ecosystems.aqara]
-is_bridge_target = false
-supported_matter_protocols = ["matter-over-wifi", "matter-over-thread"]
-supported_matter_device_types = []
+supports_external_integrations = false
+supported_matter_protocols = ["matter-over-thread"]
+supported_matter_device_types = ["*"]
 
 [identifying_attributes]
 smart_lamp = ["protocol", "ecosystem", "socket_type", "wattage_w", "rgb_support", "color_temp_min_k", "color_temp_max_k", "brightness_lm"]

--- a/services/catalog-builder/cmd/catalog-builder/config.local.toml
+++ b/services/catalog-builder/cmd/catalog-builder/config.local.toml
@@ -10,24 +10,45 @@ taxonomy_schema_path = "taxonomy_schema.json"
 strict_schema = false
 
 [ecosystems]
-cloud = ["yandex", "sber", "vk"]
-matter = ["apple", "google"]
-matter_protocols = ["matter-over-wifi", "matter-over-thread"]
+
+[ecosystems.apple]
+is_bridge_target = true
+supported_matter_protocols = ["matter-over-wifi", "matter-over-thread"]
+supported_matter_device_types = [] # empty = all types supported
+
+[ecosystems.google]
+is_bridge_target = true
+supported_matter_protocols = ["matter-over-wifi", "matter-over-thread"]
+supported_matter_device_types = []
+
+[ecosystems.yandex]
+is_bridge_target = true
+supported_matter_protocols = ["matter-over-wifi"]
+supported_matter_device_types = ["smart_lamp"]
+
+[ecosystems.sber]
+is_bridge_target = true
+supported_matter_protocols = []
+supported_matter_device_types = []
+
+[ecosystems.vk]
+is_bridge_target = true
+supported_matter_protocols = []
+supported_matter_device_types = []
+
+[ecosystems.aqara]
+is_bridge_target = false
+supported_matter_protocols = ["matter-over-wifi", "matter-over-thread"]
+supported_matter_device_types = []
 
 [identifying_attributes]
-smart_lamp = ["socket_type", "wattage_w", "rgb_support"]
-
-water_leak_sensor = ["battery_type"]
-door_window_sensor = ["battery_type"]
-motion_sensor = ["sensor_type"]
-gas_leak_sensor = ["has_audio_alert"]
-
-smart_camera = ["resolution", "indoor_outdoor"]
-
-smart_doorbell = ["has_camera", "resolution"]
-
-smart_lock = ["battery_type"]
-
-smart_siren = ["indoor_outdoor", "max_volume_db"]
-
-smart_hub = ["has_ir_blaster", "has_local_processing"]
+smart_lamp = ["protocol", "ecosystem", "socket_type", "wattage_w", "rgb_support", "color_temp_min_k", "color_temp_max_k", "brightness_lm"]
+water_leak_sensor = ["protocol", "ecosystem", "battery_type", "battery_quantity", "ip_rating", "has_audio_alert", "detects_leaks_above", "detects_leaks_below"]
+door_window_sensor = ["protocol", "ecosystem", "battery_type", "battery_quantity", "ip_rating"]
+motion_sensor = ["protocol", "ecosystem", "sensor_type", "detection_range_m", "detection_angle_deg", "battery_type", "has_light_sensor"]
+gas_leak_sensor = ["protocol", "ecosystem", "detected_gas", "power_source", "has_audio_alert", "battery_type"]
+smart_camera = ["protocol", "ecosystem", "resolution", "indoor_outdoor", "ptz", "has_two_way_audio", "power_source", "field_of_view_deg"]
+smart_doorbell = ["protocol", "ecosystem", "has_camera", "resolution", "has_two_way_audio", "power_source", "has_night_vision"]
+smart_lock = ["protocol", "ecosystem", "access_methods", "battery_type", "battery_quantity", "door_thickness_min_mm", "door_thickness_max_mm"]
+smart_siren = ["protocol", "ecosystem", "indoor_outdoor", "max_volume_db", "power_source", "has_strobe_light"]
+smart_hub = ["protocol", "ecosystem", "has_ir_blaster", "has_local_processing", "matter_bridge", "zigbee_version", "wired_connection"]

--- a/services/catalog-builder/internal/catalogbuilder/catalogbuilder.go
+++ b/services/catalog-builder/internal/catalogbuilder/catalogbuilder.go
@@ -5,6 +5,7 @@ import (
 	"slices"
 	"sort"
 
+	"github.com/Intelligent-Smart-Home-Design-System/monorepo/services/catalog-builder/internal/config"
 	"github.com/Intelligent-Smart-Home-Design-System/monorepo/services/catalog-builder/internal/domain"
 
 	"github.com/rs/zerolog"
@@ -12,9 +13,7 @@ import (
 
 type BuilderConfig struct {
 	IdentifyingAttributes map[string][]string
-	CloudEcosystems       []string
-	MatterEcosystems      []string
-	MatterProtocols       []string
+	Ecosystems            map[string]config.EcosystemConfig
 	TaxonomySchemaPath    string
 	// StrictSchema skips devices that fail schema validation instead of just warning
 	StrictSchema bool
@@ -124,6 +123,15 @@ func (b *Builder) Build(listings []*domain.ExtractedListing, compat []*domain.Sc
 			model = fmt.Sprintf("%s:%s", brand, *cluster[0].Model)
 		}
 
+		if category == "smart_hub" {
+			// special rule - if hub supports matter-over-wifi and ecosystem supports matter-over-wifi too, add support for it
+			attrs := device.DeviceAttributes
+			protocol := getStringSet(attrs, "protocol")
+			if slices.Contains(protocol, "wifi") && !slices.Contains(protocol, "matter-over-wifi") {
+				device.DeviceAttributes["protocol"] = append(protocol, "matter-over-wifi")
+			}
+		}
+
 		devices = append(devices, device)
 		modelToDevice[model] = device
 	}
@@ -139,10 +147,10 @@ func (b *Builder) Build(listings []*domain.ExtractedListing, compat []*domain.Sc
 				Msg("scraped compat record references unknown device")
 			continue
 		}
-		device.DirectCompatibility = append(device.DirectCompatibility, &domain.DirectCompatibility{
-			Ecosystem: c.Ecosystem,
-			Protocol:  c.Protocol,
-		})
+		if c.Ecosystem == device.Brand {
+			continue // skip - added as generic rule
+		}
+		addDirect(device, c.Ecosystem, c.Protocol)
 	}
 
 	for _, d := range devices {
@@ -156,72 +164,56 @@ func (b *Builder) buildCompatibilityLinks(d *domain.Device) {
 	ecosystems := getStringSet(d.DeviceAttributes, "ecosystem")
 	protocols := getStringSet(d.DeviceAttributes, "protocol")
 
-	alreadyDirectCompat := make(map[string]bool)
-	for _, dc := range d.DirectCompatibility {
-		alreadyDirectCompat[dc.Ecosystem] = true
-	}
-
-	var vendorEcosystems []string
 	for _, eco := range ecosystems {
-		if !slices.Contains(b.cfg.CloudEcosystems, eco) && !slices.Contains(b.cfg.MatterEcosystems, eco) {
-			vendorEcosystems = append(vendorEcosystems, eco)
+		if eco == d.Brand {
 			for _, proto := range protocols {
-				d.DirectCompatibility = append(d.DirectCompatibility, &domain.DirectCompatibility{
-					Ecosystem: eco,
-					Protocol:  proto,
-				})
+				addDirect(d, eco, proto)
 			}
-			alreadyDirectCompat[eco] = true
-		}
-	}
-
-	hasMatter := false
-	for _, proto := range protocols {
-		if slices.Contains(b.cfg.MatterProtocols, proto) {
-			hasMatter = true
-			break
 		}
 	}
 
 	for _, eco := range ecosystems {
-		if !slices.Contains(b.cfg.MatterEcosystems, eco) {
-			continue
-		}
-		if hasMatter {
+		config := b.cfg.Ecosystems[eco]
+		if !config.IsBridgeTarget {
 			for _, proto := range protocols {
-				if slices.Contains(b.cfg.MatterProtocols, proto) {
-					d.DirectCompatibility = append(d.DirectCompatibility, &domain.DirectCompatibility{
-						Ecosystem: eco,
-						Protocol:  proto,
+				addDirect(d, eco, proto)
+			}
+			for _, ecoTarget := range ecosystems {
+				targetConfig := b.cfg.Ecosystems[ecoTarget]
+				if targetConfig.IsBridgeTarget {
+					d.BridgeCompatibility = append(d.BridgeCompatibility, &domain.BridgeCompatibility{
+						SourceEcosystem: eco,
+						TargetEcosystem: ecoTarget,
+						Protocol:        "cloud",
 					})
 				}
 			}
-		} else {
-			for _, vendor := range vendorEcosystems {
-				d.BridgeCompatibility = append(d.BridgeCompatibility, &domain.BridgeCompatibility{
-					SourceEcosystem: vendor,
-					TargetEcosystem: eco,
-					Protocol:        "cloud",
-				})
+		}
+
+		// matter
+		if len(config.SupportedMatterProtocols) == 0 || len(config.SupportedMatterDeviceTypes) > 0 && !slices.Contains(config.SupportedMatterDeviceTypes, d.Category) {
+			continue
+		}
+
+		protocol := getStringSet(d.DeviceAttributes, "protocol")
+		for _, matterProtocol := range config.SupportedMatterProtocols {
+			if slices.Contains(protocol, matterProtocol) {
+				addDirect(d, eco, matterProtocol)
 			}
 		}
 	}
+}
 
-	for _, eco := range ecosystems {
-		if !slices.Contains(b.cfg.CloudEcosystems, eco) {
-			continue
-		}
-		if alreadyDirectCompat[eco] {
-			continue
-		}
-		for _, vendor := range vendorEcosystems {
-			d.BridgeCompatibility = append(d.BridgeCompatibility, &domain.BridgeCompatibility{
-				SourceEcosystem: vendor,
-				TargetEcosystem: eco,
-				Protocol:        "cloud",
-			})
+func addDirect(d *domain.Device, ecosystem string, protocol string) {
+	for _, c := range d.DirectCompatibility {
+		if c.Ecosystem == ecosystem && c.Protocol == protocol {
+			return
 		}
 	}
+	d.DirectCompatibility = append(d.DirectCompatibility, &domain.DirectCompatibility{
+		Ecosystem: ecosystem,
+		Protocol:  protocol,
+	})
 }
 
 func getStringSet(attrs map[string]any, key string) []string {

--- a/services/catalog-builder/internal/catalogbuilder/catalogbuilder.go
+++ b/services/catalog-builder/internal/catalogbuilder/catalogbuilder.go
@@ -11,6 +11,8 @@ import (
 	"github.com/rs/zerolog"
 )
 
+const smartHubCategory = "smart_hub"
+
 type BuilderConfig struct {
 	IdentifyingAttributes map[string][]string
 	Ecosystems            map[string]config.EcosystemConfig
@@ -123,7 +125,7 @@ func (b *Builder) Build(listings []*domain.ExtractedListing, compat []*domain.Sc
 			model = fmt.Sprintf("%s:%s", brand, *cluster[0].Model)
 		}
 
-		if category == "smart_hub" {
+		if category == smartHubCategory {
 			// special rule - if hub supports matter-over-wifi and ecosystem supports matter-over-wifi too, add support for it
 			attrs := device.DeviceAttributes
 			protocol := getStringSet(attrs, "protocol")
@@ -174,13 +176,16 @@ func (b *Builder) buildCompatibilityLinks(d *domain.Device) {
 
 	for _, eco := range ecosystems {
 		config := b.cfg.Ecosystems[eco]
-		if !config.IsBridgeTarget {
+		if !config.SupportsExternalIntegrations {
 			for _, proto := range protocols {
 				addDirect(d, eco, proto)
 			}
+			if d.Category == smartHubCategory {
+				continue
+			}
 			for _, ecoTarget := range ecosystems {
 				targetConfig := b.cfg.Ecosystems[ecoTarget]
-				if targetConfig.IsBridgeTarget {
+				if targetConfig.SupportsExternalIntegrations {
 					d.BridgeCompatibility = append(d.BridgeCompatibility, &domain.BridgeCompatibility{
 						SourceEcosystem: eco,
 						TargetEcosystem: ecoTarget,
@@ -191,14 +196,15 @@ func (b *Builder) buildCompatibilityLinks(d *domain.Device) {
 		}
 
 		// matter
-		if len(config.SupportedMatterProtocols) == 0 || len(config.SupportedMatterDeviceTypes) > 0 && !slices.Contains(config.SupportedMatterDeviceTypes, d.Category) {
+		if d.Category == smartHubCategory && config.SupportsExternalIntegrations {
 			continue
 		}
-
-		protocol := getStringSet(d.DeviceAttributes, "protocol")
-		for _, matterProtocol := range config.SupportedMatterProtocols {
-			if slices.Contains(protocol, matterProtocol) {
-				addDirect(d, eco, matterProtocol)
+		if config.SupportsMatterDeviceType(d.Category) {
+			protocol := getStringSet(d.DeviceAttributes, "protocol")
+			for _, matterProtocol := range config.SupportedMatterProtocols {
+				if slices.Contains(protocol, matterProtocol) {
+					addDirect(d, eco, matterProtocol)
+				}
 			}
 		}
 	}

--- a/services/catalog-builder/internal/catalogbuilder/catalogbuilder_test.go
+++ b/services/catalog-builder/internal/catalogbuilder/catalogbuilder_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/Intelligent-Smart-Home-Design-System/monorepo/services/catalog-builder/internal/config"
 	"github.com/Intelligent-Smart-Home-Design-System/monorepo/services/catalog-builder/internal/domain"
 
 	"github.com/rs/zerolog"
@@ -16,9 +17,31 @@ func defaultCfg() BuilderConfig {
 		IdentifyingAttributes: map[string][]string{
 			"smart_lamp": {"socket_type", "wattage_w"},
 		},
-		CloudEcosystems:  []string{"yandex", "sber", "vk"},
-		MatterEcosystems: []string{"apple", "google"},
-		MatterProtocols:  []string{"matter-over-wifi", "matter-over-thread"},
+		Ecosystems: map[string]config.EcosystemConfig{
+			"yandex": {
+				IsBridgeTarget:             true,
+				SupportedMatterProtocols:   []string{"matter-over-wifi"},
+				SupportedMatterDeviceTypes: []string{"smart-lamp"},
+			},
+			"sber": {
+				IsBridgeTarget: true,
+			},
+			"vk": {
+				IsBridgeTarget: true,
+			},
+			"apple": {
+				IsBridgeTarget:           true,
+				SupportedMatterProtocols: []string{"matter-over-wifi", "matter-over-thread"},
+			},
+			"google": {
+				IsBridgeTarget:           true,
+				SupportedMatterProtocols: []string{"matter-over-wifi", "matter-over-thread"},
+			},
+			"aqara": {
+				IsBridgeTarget:           false,
+				SupportedMatterProtocols: []string{"matter-over-wifi", "matter-over-thread"},
+			},
+		},
 	}
 }
 

--- a/services/catalog-builder/internal/catalogbuilder/catalogbuilder_test.go
+++ b/services/catalog-builder/internal/catalogbuilder/catalogbuilder_test.go
@@ -19,27 +19,27 @@ func defaultCfg() BuilderConfig {
 		},
 		Ecosystems: map[string]config.EcosystemConfig{
 			"yandex": {
-				IsBridgeTarget:             true,
-				SupportedMatterProtocols:   []string{"matter-over-wifi"},
-				SupportedMatterDeviceTypes: []string{"smart-lamp"},
+				SupportsExternalIntegrations: true,
+				SupportedMatterProtocols:     []string{"matter-over-wifi"},
+				SupportedMatterDeviceTypes:   []string{"smart-lamp"},
 			},
 			"sber": {
-				IsBridgeTarget: true,
+				SupportsExternalIntegrations: true,
 			},
 			"vk": {
-				IsBridgeTarget: true,
+				SupportsExternalIntegrations: true,
 			},
 			"apple": {
-				IsBridgeTarget:           true,
-				SupportedMatterProtocols: []string{"matter-over-wifi", "matter-over-thread"},
+				SupportsExternalIntegrations: true,
+				SupportedMatterProtocols:     []string{"matter-over-wifi", "matter-over-thread"},
 			},
 			"google": {
-				IsBridgeTarget:           true,
-				SupportedMatterProtocols: []string{"matter-over-wifi", "matter-over-thread"},
+				SupportsExternalIntegrations: true,
+				SupportedMatterProtocols:     []string{"matter-over-wifi", "matter-over-thread"},
 			},
 			"aqara": {
-				IsBridgeTarget:           false,
-				SupportedMatterProtocols: []string{"matter-over-wifi", "matter-over-thread"},
+				SupportsExternalIntegrations: false,
+				SupportedMatterProtocols:     []string{"matter-over-wifi", "matter-over-thread"},
 			},
 		},
 	}

--- a/services/catalog-builder/internal/catalogbuilder/catalogbuilder_test.go
+++ b/services/catalog-builder/internal/catalogbuilder/catalogbuilder_test.go
@@ -32,14 +32,17 @@ func defaultCfg() BuilderConfig {
 			"apple": {
 				SupportsExternalIntegrations: true,
 				SupportedMatterProtocols:     []string{"matter-over-wifi", "matter-over-thread"},
+				SupportedMatterDeviceTypes:   []string{"*"},
 			},
 			"google": {
 				SupportsExternalIntegrations: true,
 				SupportedMatterProtocols:     []string{"matter-over-wifi", "matter-over-thread"},
+				SupportedMatterDeviceTypes:   []string{"*"},
 			},
 			"aqara": {
 				SupportsExternalIntegrations: false,
 				SupportedMatterProtocols:     []string{"matter-over-wifi", "matter-over-thread"},
+				SupportedMatterDeviceTypes:   []string{"*"},
 			},
 		},
 	}

--- a/services/catalog-builder/internal/catalogbuilder/dedup.go
+++ b/services/catalog-builder/internal/catalogbuilder/dedup.go
@@ -3,6 +3,7 @@ package catalogbuilder
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 
@@ -53,6 +54,24 @@ func attributeToString(val any) (string, error) {
 		return fmt.Sprintf("%.1f", v), nil
 	case bool:
 		return fmt.Sprintf("%t", v), nil
+	case []any:
+		strs := make([]string, 0, len(v))
+		for _, s := range v {
+			if s, ok := s.(string); ok {
+				strs = append(strs, s)
+			}
+		}
+		slices.Sort(strs)
+		sb := strings.Builder{}
+		for i, s := range strs {
+			sb.WriteString(s)
+			if i != len(strs)-1 {
+				sb.WriteRune(',')
+			}
+		}
+		return sb.String(), nil
+	case nil:
+		return "null", nil
 	default:
 		return "", fmt.Errorf("%w: %T", errUnsupportedAttr, val)
 	}

--- a/services/catalog-builder/internal/catalogbuilder/dedup_test.go
+++ b/services/catalog-builder/internal/catalogbuilder/dedup_test.go
@@ -144,6 +144,18 @@ func TestGetSecondaryKey(t *testing.T) {
 			expectedKey: "test:device:",
 		},
 		{
+			name: "string array attribute",
+			listing: &domain.ExtractedListing{
+				Brand:    "test",
+				Category: "device",
+				DeviceAttributes: map[string]any{
+					"attr": []any{"cc", "aa", "bb"},
+				},
+			},
+			attrs:       []string{"attr"},
+			expectedKey: "test:device:aa,bb,cc",
+		},
+		{
 			name: "different integer types",
 			listing: &domain.ExtractedListing{
 				Brand:    "test",
@@ -162,6 +174,33 @@ func TestGetSecondaryKey(t *testing.T) {
 			},
 			attrs:       []string{"int8", "int16", "int32", "int64", "uint", "uint8", "uint16", "uint32", "uint64"},
 			expectedKey: "test:device:-10:1000:50000:1000000:255:200:60000:4000000:1000000000",
+		},
+		{
+			name: "attribute is null",
+			listing: &domain.ExtractedListing{
+				Brand:    "aqara",
+				Category: "sensor",
+				DeviceAttributes: map[string]any{
+					"protocol": nil,
+				},
+			},
+			attrs:       []string{"protocol"},
+			expectedKey: "aqara:sensor:null",
+		},
+
+		{
+			name: "multiple attributes with one null",
+			listing: &domain.ExtractedListing{
+				Brand:    "test",
+				Category: "device",
+				DeviceAttributes: map[string]any{
+					"protocol": "wifi",
+					"range":    100,
+					"attr":     nil,
+				},
+			},
+			attrs:       []string{"protocol", "attr", "range"},
+			expectedKey: "test:device:wifi:null:100",
 		},
 
 		// Error cases

--- a/services/catalog-builder/internal/cli/run.go
+++ b/services/catalog-builder/internal/cli/run.go
@@ -66,9 +66,7 @@ func run(ctx context.Context, cfgFile string) error {
 
 	builder, err := catalogbuilder.NewBuilder(catalogbuilder.BuilderConfig{
 		IdentifyingAttributes: cfg.IdentifyingAttributes,
-		CloudEcosystems:       cfg.Ecosystems.Cloud,
-		MatterEcosystems:      cfg.Ecosystems.Matter,
-		MatterProtocols:       cfg.Ecosystems.MatterProtocols,
+		Ecosystems:            cfg.Ecosystems,
 		TaxonomySchemaPath:    cfg.TaxonomySchemaPath,
 		StrictSchema:          cfg.StrictSchema,
 	}, log)

--- a/services/catalog-builder/internal/config/config.go
+++ b/services/catalog-builder/internal/config/config.go
@@ -1,11 +1,11 @@
 package config
 
 type Config struct {
-	Database              DatabaseConfig      `mapstructure:"database"`
-	IdentifyingAttributes map[string][]string `mapstructure:"identifying_attributes"`
-	TaxonomySchemaPath    string              `mapstructure:"taxonomy_schema_path"`
-	StrictSchema          bool                `mapstructure:"strict_schema"`
-	Ecosystems            EcosystemsConfig    `mapstructure:"ecosystems"`
+	Database              DatabaseConfig             `mapstructure:"database"`
+	IdentifyingAttributes map[string][]string        `mapstructure:"identifying_attributes"`
+	TaxonomySchemaPath    string                     `mapstructure:"taxonomy_schema_path"`
+	StrictSchema          bool                       `mapstructure:"strict_schema"`
+	Ecosystems            map[string]EcosystemConfig `mapstructure:"ecosystems"`
 }
 
 type DatabaseConfig struct {
@@ -17,13 +17,8 @@ type DatabaseConfig struct {
 	SSLMode  string `mapstructure:"sslmode"`
 }
 
-type EcosystemsConfig struct {
-	// "cloud-integration" ecosystems like yandex, sber, vk
-	// that have direct compatibility lists in their documentation
-	Cloud []string `mapstructure:"cloud"`
-	// matter enabled ecosystems that support most devices
-	// using matter protocols (matter-over-thread or matter-over-wifi)
-	Matter []string `mapstructure:"matter"`
-	// matter protocol ids
-	MatterProtocols []string `mapstructure:"matter_protocols"`
+type EcosystemConfig struct {
+	IsBridgeTarget             bool     `mapstructure:"is_bridge_target"`
+	SupportedMatterProtocols   []string `mapstructure:"supported_matter_protocols"`
+	SupportedMatterDeviceTypes []string `mapstructure:"supported_matter_device_types"`
 }

--- a/services/catalog-builder/internal/config/config.go
+++ b/services/catalog-builder/internal/config/config.go
@@ -1,5 +1,7 @@
 package config
 
+import "slices"
+
 type Config struct {
 	Database              DatabaseConfig             `mapstructure:"database"`
 	IdentifyingAttributes map[string][]string        `mapstructure:"identifying_attributes"`
@@ -18,7 +20,14 @@ type DatabaseConfig struct {
 }
 
 type EcosystemConfig struct {
-	IsBridgeTarget             bool     `mapstructure:"is_bridge_target"`
-	SupportedMatterProtocols   []string `mapstructure:"supported_matter_protocols"`
-	SupportedMatterDeviceTypes []string `mapstructure:"supported_matter_device_types"`
+	SupportsExternalIntegrations bool     `mapstructure:"supports_external_integrations"`
+	SupportedMatterProtocols     []string `mapstructure:"supported_matter_protocols"`
+	SupportedMatterDeviceTypes   []string `mapstructure:"supported_matter_device_types"`
+}
+
+func (eco *EcosystemConfig) SupportsMatterDeviceType(deviceType string) bool {
+	if len(eco.SupportedMatterDeviceTypes) == 1 && eco.SupportedMatterDeviceTypes[0] == "*" {
+		return true
+	}
+	return slices.Contains(eco.SupportedMatterDeviceTypes, deviceType)
 }

--- a/services/catalog-builder/internal/repository/postgres_repository_test.go
+++ b/services/catalog-builder/internal/repository/postgres_repository_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package repository_test
 
 import (


### PR DESCRIPTION
- сделал конфиг экосистем в более удобном формате
    - is_bridge_target - можно ли пробрасывать туда девайсы по облачным/иным интеграциям (default=false)
    - supported matter protocols/device types (default = не поддерживается matter)
- сделал конфиг для идентифицирующих атрибутов более специфичный (больше полей добавил) чтобы избежать ложных мерджей