### PR TITLE
Fix catalog: fix apply filter func and add tests

### DIFF
--- a/services/device-selection/src/device_selection/data/catalog.py
+++ b/services/device-selection/src/device_selection/data/catalog.py
@@ -91,6 +91,11 @@ def _apply_filter(attr: Any, f: Filter) -> bool:
         return attr is not None
     if attr is None:
         return False
+    if isinstance(attr, list) and not isinstance(f.value, list):
+        if f.op == FilterOp.EQ:
+            return f.value in attr
+        if f.op == FilterOp.NEQ:
+            return f.value not in attr
     if f.op != FilterOp.CONTAINS:
         if type(attr) is not type(f.value) and not _numeric_compatible(attr, f.value):
             raise TypeError(
@@ -121,4 +126,3 @@ def _apply_filter(attr: Any, f: Filter) -> bool:
             return f.value in attr
         case _:
             raise ValueError(f"unknown filter op: {f.op}")
-

--- a/services/device-selection/tests/data/test_catalog.py
+++ b/services/device-selection/tests/data/test_catalog.py
@@ -47,6 +47,18 @@ class TestApplyFilter:
     def test_neq_match(self):
         assert _apply_filter("wifi", Filter("protocol", FilterOp.NEQ, "zigbee")) is True
 
+    def test_eq_scalar_matches_list_attribute_member(self):
+        assert _apply_filter(["methane", "natural_gas"], Filter("gas_types", FilterOp.EQ, "methane")) is True
+
+    def test_eq_scalar_does_not_match_missing_list_attribute_member(self):
+        assert _apply_filter(["natural_gas"], Filter("gas_types", FilterOp.EQ, "methane")) is False
+
+    def test_neq_scalar_matches_missing_list_attribute_member(self):
+        assert _apply_filter(["natural_gas"], Filter("gas_types", FilterOp.NEQ, "methane")) is True
+
+    def test_neq_scalar_does_not_match_list_attribute_member(self):
+        assert _apply_filter(["methane", "natural_gas"], Filter("gas_types", FilterOp.NEQ, "methane")) is False
+
     def test_eq_type_mismatch_raises(self):
         with pytest.raises(TypeError, match="type mismatch"):
             _apply_filter("5", Filter("wattage", FilterOp.EQ, 5))


### PR DESCRIPTION
Пофиксил пайплайн, ошибка была:

в каталоге атрибут хранится списком:
  "gas_types": ["methane", "natural_gas"]

  а фильтр приходит строкой:
  "gas_types" EQ "methane"

  До фикса код считал это ошибкой типов: list против str.