### PR TITLE
Fix cycle dependencies logic

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -6,6 +6,7 @@ COPY frontend/apps/ ./apps/
 COPY frontend/packages/ ./packages/
 COPY services/layout/internal/configs/tracks.json /services/layout/internal/configs/tracks.json
 COPY services/layout/internal/configs/devices.json /services/layout/internal/configs/devices.json
+COPY services/layout/internal/configs/dependencies.json /services/layout/internal/configs/dependencies.json
 COPY services/simulation/configs/dependencies.json /services/simulation/configs/dependencies.json
 COPY services/simulation/configs/entities.json /services/simulation/configs/entities.json
 

--- a/frontend/apps/web/src/app/lib/dependency-cycle.ts
+++ b/frontend/apps/web/src/app/lib/dependency-cycle.ts
@@ -1,0 +1,64 @@
+export type DependencyGraph = Record<string, string[]>;
+
+type DependencyRules = {
+  triggers?: Record<string, { triggers?: string[] }>;
+};
+
+export function dependencyGraphForDeviceTypes(deviceTypes: string[], rules: DependencyRules): DependencyGraph {
+  const selected = new Set(deviceTypes.filter(Boolean));
+  const graph: DependencyGraph = {};
+
+  Array.from(selected)
+    .sort()
+    .forEach((deviceType) => {
+      graph[deviceType] = (rules.triggers?.[deviceType]?.triggers ?? []).filter((target) => selected.has(target));
+    });
+
+  return graph;
+}
+
+export function findDependencyCycle(graph: DependencyGraph | null | undefined): string[] {
+  if (!graph) return [];
+
+  const state = new Map<string, "visiting" | "visited">();
+  const path: string[] = [];
+  const pathIndex = new Map<string, number>();
+
+  const visit = (node: string): string[] => {
+    state.set(node, "visiting");
+    pathIndex.set(node, path.length);
+    path.push(node);
+
+    const targets = [...(graph[node] ?? [])].sort();
+    for (const target of targets) {
+      if (state.get(target) === "visiting") {
+        const start = pathIndex.get(target) ?? 0;
+        return [...path.slice(start), target];
+      }
+      if (!state.has(target)) {
+        const cycle = visit(target);
+        if (cycle.length) return cycle;
+      }
+    }
+
+    path.pop();
+    pathIndex.delete(node);
+    state.set(node, "visited");
+    return [];
+  };
+
+  for (const node of Object.keys(graph).sort()) {
+    if (!state.has(node)) {
+      const cycle = visit(node);
+      if (cycle.length) return cycle;
+    }
+  }
+
+  return [];
+}
+
+export function dependencyCycleMessage(cycle: string[], names: Record<string, string> = {}) {
+  if (!cycle.length) return "";
+  const chain = cycle.map((id) => names[id] ?? id).join(" → ");
+  return `Обнаружена циклическая зависимость между устройствами: ${chain}. Исправьте конфигурацию.`;
+}

--- a/frontend/apps/web/src/app/plan/page.tsx
+++ b/frontend/apps/web/src/app/plan/page.tsx
@@ -27,6 +27,7 @@ import {
 import Image from "next/image";
 import { api } from "../lib/api";
 import { useAuth } from "../lib/auth-context";
+import { dependencyCycleMessage, findDependencyCycle } from "../lib/dependency-cycle";
 import type { ApiHomePlan, ApiPipelineResult, ApiPlanStageArtifact, ApiPlanStatus } from "../lib/types";
 import { ApartmentPlanPreview } from "./ApartmentPlanPreview";
 
@@ -58,6 +59,11 @@ type PipelineStatusResponse = {
   layout?: unknown;
   dependencies?: Record<string, string[]> | null;
   device_selection?: unknown;
+  error?: {
+    code?: string;
+    message?: string;
+    cycle?: string[];
+  } | null;
 };
 
 type SimulationDevice = {
@@ -159,7 +165,11 @@ function PlanPageContent() {
             setPlan(pipelineResultToPlan(currentResult, Number(budgetFromStorage()) || 0));
             setLoading(false);
             if (normalizedStatus === "failed") {
-              setError("Pipeline завершился с ошибкой. Подробности статуса показаны в промежуточных этапах.");
+              setError(
+                dependencyCycleMessage(currentResult.error?.cycle ?? []) ||
+                  currentResult.error?.message ||
+                  "Pipeline завершился с ошибкой. Подробности статуса показаны в промежуточных этапах."
+              );
               return;
             }
             timer = setTimeout(loadStatus, 4000);
@@ -222,6 +232,8 @@ function PlanPageContent() {
     [plan, selectedBundleId]
   );
   const isManualPlan = plan?.main_ecosystem_id === "manual";
+  const dependencyCycle = useMemo(() => findDependencyCycle(plan?.dependencies), [plan?.dependencies]);
+  const dependencyError = dependencyCycleMessage(dependencyCycle);
 
   const selectedListing = useMemo(
     () =>
@@ -364,6 +376,7 @@ function PlanPageContent() {
         ) : (
           <Stack spacing={2.5}>
             {error && <Alert severity="error">{error}</Alert>}
+            {dependencyError && <Alert severity="error">{dependencyError}</Alert>}
 
             <Card sx={surfaceCardSx}>
               <CardContent>
@@ -694,7 +707,7 @@ function PlanPageContent() {
 
                       <Button
                         variant="outlined"
-                        disabled={!selectedBundle.listings.length}
+                        disabled={!selectedBundle.listings.length || dependencyCycle.length > 0 || status?.status !== "completed"}
                         onClick={() =>
                           openSimulation(selectedBundle, simulationFloorData, plan?.dependencies, isManualPlan)
                         }

--- a/frontend/apps/web/src/app/settings/page.tsx
+++ b/frontend/apps/web/src/app/settings/page.tsx
@@ -42,7 +42,13 @@ import {
   saveManualSelection,
   type ManualSelectionItem,
 } from "../lib/manual-selection";
+import {
+  dependencyCycleMessage,
+  dependencyGraphForDeviceTypes,
+  findDependencyCycle,
+} from "../lib/dependency-cycle";
 import tracksConfig from "../../../../../../services/layout/internal/configs/tracks.json";
+import dependenciesConfig from "../../../../../../services/layout/internal/configs/dependencies.json";
 import type {
   ApiCatalogCategory,
   ApiDeviceType,
@@ -231,6 +237,17 @@ export default function SettingsPage() {
     [requirementsByTrack, selectedTrackSelections]
   );
 
+  const dependencyCycle = useMemo(() => {
+    if (selectionMode !== "auto") return [];
+    const selectedDeviceTypes = selectedRequirements.map((requirement) => requirement.device_type);
+    return findDependencyCycle(dependencyGraphForDeviceTypes(selectedDeviceTypes, dependenciesConfig));
+  }, [selectedRequirements, selectionMode]);
+  const dependencyTypeNames = useMemo(
+    () => Object.fromEntries(deviceTypes.map((deviceType) => [deviceType.id, deviceType.name])),
+    [deviceTypes]
+  );
+  const dependencyError = dependencyCycleMessage(dependencyCycle, dependencyTypeNames);
+
   const budgetMissing = budget.trim().length === 0;
   const budgetValue = Number(budget);
   const budgetIsValid = !budgetMissing && Number.isFinite(budgetValue) && budgetValue > 0;
@@ -240,6 +257,7 @@ export default function SettingsPage() {
   const canSubmitAuto =
     budgetIsValid &&
     mainEcosystemId.length > 0 &&
+    dependencyCycle.length === 0 &&
     !parsingFloor &&
     Boolean(parsedFloor) &&
     selectedRequirements.some((item) => item.device_type && item.quantity > 0);
@@ -1144,6 +1162,7 @@ export default function SettingsPage() {
 
                 {selectionMode === "auto" && (
                   <>
+                    {dependencyError && <Alert severity="error">{dependencyError}</Alert>}
                     <Button
                       variant="contained"
                       fullWidth

--- a/services/layout/internal/events/engine/dependency_cycle.go
+++ b/services/layout/internal/events/engine/dependency_cycle.go
@@ -1,0 +1,55 @@
+package engine
+
+import "sort"
+
+// FindDependencyCycle returns one closed dependency chain or nil when the graph is acyclic.
+func FindDependencyCycle(dependencies map[string][]string) []string {
+	const (
+		unvisited = iota
+		visiting
+		visited
+	)
+
+	state := make(map[string]int, len(dependencies))
+	path := make([]string, 0, len(dependencies))
+	pathIndex := make(map[string]int, len(dependencies))
+	nodes := make([]string, 0, len(dependencies))
+	for node := range dependencies {
+		nodes = append(nodes, node)
+	}
+	sort.Strings(nodes)
+
+	var visit func(string) []string
+	visit = func(node string) []string {
+		state[node] = visiting
+		pathIndex[node] = len(path)
+		path = append(path, node)
+		targets := append([]string(nil), dependencies[node]...)
+		sort.Strings(targets)
+		for _, target := range targets {
+			switch state[target] {
+			case visiting:
+				start := pathIndex[target]
+				cycle := append([]string(nil), path[start:]...)
+				return append(cycle, target)
+			case unvisited:
+				if cycle := visit(target); len(cycle) > 0 {
+					return cycle
+				}
+			}
+		}
+		path = path[:len(path)-1]
+		delete(pathIndex, node)
+		state[node] = visited
+		return nil
+	}
+
+	for _, node := range nodes {
+		if state[node] == unvisited {
+			if cycle := visit(node); len(cycle) > 0 {
+				return cycle
+			}
+		}
+	}
+	return nil
+}

--- a/services/layout/internal/events/engine/dependency_cycle_test.go
+++ b/services/layout/internal/events/engine/dependency_cycle_test.go
@@ -1,0 +1,30 @@
+package engine
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestFindDependencyCycle verifies cycle detection and the returned closed chain.
+func TestFindDependencyCycle(t *testing.T) {
+	dependencies := map[string][]string{
+		"sensor": {"lamp"},
+		"lamp":   {"switch"},
+		"switch": {"sensor"},
+	}
+	want := []string{"lamp", "switch", "sensor", "lamp"}
+	if got := FindDependencyCycle(dependencies); !reflect.DeepEqual(got, want) {
+		t.Fatalf("FindDependencyCycle() = %v, want %v", got, want)
+	}
+}
+
+// TestFindDependencyCycleReturnsNil verifies that an acyclic dependency graph is accepted.
+func TestFindDependencyCycleReturnsNil(t *testing.T) {
+	dependencies := map[string][]string{
+		"sensor": {"lamp"},
+		"lamp":   nil,
+	}
+	if got := FindDependencyCycle(dependencies); got != nil {
+		t.Fatalf("FindDependencyCycle() = %v, want nil", got)
+	}
+}

--- a/services/layout/internal/temporalworker/activities.go
+++ b/services/layout/internal/temporalworker/activities.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Intelligent-Smart-Home-Design-System/monorepo/services/layout/internal/point"
 	"github.com/Intelligent-Smart-Home-Design-System/monorepo/services/layout/internal/rules/storage"
 	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/temporal"
 )
 
 type PlaceDevicesInput struct {
@@ -75,6 +76,15 @@ func (a *Activities) PlaceDevices(ctx context.Context, input PlaceDevicesInput) 
 	if err != nil {
 		logger.Error("failed to generate scenario dependencies", "request_id", input.RequestID, "error", err)
 		return PlaceDevicesOutput{}, err
+	}
+	if cycle := engine.FindDependencyCycle(dependencies); len(cycle) > 0 {
+		logger.Error("cyclic device dependencies detected", "request_id", input.RequestID, "cycle", cycle)
+		return PlaceDevicesOutput{}, temporal.NewNonRetryableApplicationError(
+			"Обнаружена циклическая зависимость между устройствами",
+			"cyclic_dependencies",
+			nil,
+			cycle,
+		)
 	}
 
 	devicesPlaced := countPlacements(layout)

--- a/services/main-pipeline/cmd/api-gateway/main.go
+++ b/services/main-pipeline/cmd/api-gateway/main.go
@@ -33,7 +33,32 @@ import (
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/contrib/opentelemetry"
 	"go.temporal.io/sdk/interceptor"
+	"go.temporal.io/sdk/temporal"
 )
+
+type workflowErrorResponse struct {
+	Code    string   `json:"code"`
+	Message string   `json:"message"`
+	Cycle   []string `json:"cycle,omitempty"`
+}
+
+func pipelineWorkflowError(err error) workflowErrorResponse {
+	var applicationErr *temporal.ApplicationError
+	if errors.As(err, &applicationErr) && applicationErr.Type() == "cyclic_dependencies" {
+		var cycle []string
+		_ = applicationErr.Details(&cycle)
+		return workflowErrorResponse{
+			Code:    "cyclic_dependencies",
+			Message: "Обнаружена циклическая зависимость между устройствами. Исправьте конфигурацию.",
+			Cycle:   cycle,
+		}
+	}
+
+	return workflowErrorResponse{
+		Code:    "pipeline_failed",
+		Message: "Не удалось сформировать конфигурацию умного дома.",
+	}
+}
 
 func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
@@ -259,13 +284,20 @@ func buildAPI(log zerolog.Logger, temporalClient client.Client, startedTotal *pr
 
 		status := description.WorkflowExecutionInfo.Status
 		if status != enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusAccepted)
-			_ = json.NewEncoder(w).Encode(map[string]string{
+			response := map[string]any{
 				"workflow_id": workflowID,
 				"run_id":      description.WorkflowExecutionInfo.Execution.RunId,
 				"status":      status.String(),
-			})
+			}
+			if status == enumspb.WORKFLOW_EXECUTION_STATUS_FAILED {
+				var ignored pipeline.PipelineResult
+				if workflowErr := temporalClient.GetWorkflow(r.Context(), workflowID, runID).Get(r.Context(), &ignored); workflowErr != nil {
+					response["error"] = pipelineWorkflowError(workflowErr)
+				}
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusAccepted)
+			_ = json.NewEncoder(w).Encode(response)
 			return
 		}
 


### PR DESCRIPTION
Добавил проверку цикличиских зависимостей на этапе формирования конфигурации умного дома для преждевременного предупреждения до перехода в симуляцию. Проверка на бэкенде симуляции остается.

При нахождении циклической зависимости пользователь на может продолжить взаимодействие с текущей конфигурацией и ему высвечивается сообщение о том, что необходимо изменить в текущем конфиге для избежания циклических зависимостей.