### PR TITLE
added ability to create plan without authorization

### DIFF
--- a/frontend/apps/web/src/app/lib/auth-context.tsx
+++ b/frontend/apps/web/src/app/lib/auth-context.tsx
@@ -40,7 +40,6 @@ export function AuthProvider(props: { children: React.ReactNode }) {
       loading,
       async login(payload) {
         const response = normalizeAuthResponse(await api.login(payload));
-        console.log(response);
         persistAuthResponse(response, payload.email);
         setUser(response.user ?? { id: crypto.randomUUID(), email: payload.email });
       },

--- a/frontend/apps/web/src/app/lib/auth-context.tsx
+++ b/frontend/apps/web/src/app/lib/auth-context.tsx
@@ -40,13 +40,14 @@ export function AuthProvider(props: { children: React.ReactNode }) {
       loading,
       async login(payload) {
         const response = normalizeAuthResponse(await api.login(payload));
+        console.log(response);
         persistAuthResponse(response, payload.email);
-        setUser(response.user ?? { email: payload.email });
+        setUser(response.user ?? { id: crypto.randomUUID(), email: payload.email });
       },
       async register(payload) {
         const response = normalizeAuthResponse(await api.register(payload));
         persistAuthResponse(response, payload.email);
-        setUser(response.user ?? { email: payload.email, name: payload.name ?? null });
+        setUser(response.user ?? { id: crypto.randomUUID(), email: payload.email, name: payload.name ?? null });
       },
       logout() {
         clearAuthState();

--- a/frontend/apps/web/src/app/lib/auth.ts
+++ b/frontend/apps/web/src/app/lib/auth.ts
@@ -92,6 +92,7 @@ export function persistAuthResponse(response: AuthResponse, fallbackEmail?: stri
       response.user ??
       (fallbackEmail
         ? {
+            id: crypto.randomUUID(),
             email: fallbackEmail,
           }
         : null),
@@ -101,11 +102,11 @@ export function persistAuthResponse(response: AuthResponse, fallbackEmail?: stri
 function normalizeUser(value: unknown): AuthUser | null {
   if (!value || typeof value !== "object") return null;
   const user = value as Record<string, unknown>;
-  const email = pickString(user.email);
-  if (!email) return null;
+  const id = pickString(user.id);
+  if (!id) return null;
   return {
-    id: pickString(user.id) ?? (typeof user.id === "number" ? user.id : undefined),
-    email,
+    id,
+    email: pickString(user.email) ?? undefined,
     name: pickString(user.name) ?? pickString(user.full_name) ?? null,
   };
 }

--- a/frontend/apps/web/src/app/lib/types.ts
+++ b/frontend/apps/web/src/app/lib/types.ts
@@ -283,14 +283,15 @@ export type AuthTokens = {
 };
 
 export type AuthUser = {
-    id?: string | number;
-    email: string;
+    id: string;
+    email?: string;
     name?: string | null;
 };
 
 export type LoginRequest = {
-    email: string;
-    password: string;
+    email?: string;
+    password?: string;
+    is_authorising: boolean;
 };
 
 export type RegisterRequest = {

--- a/frontend/apps/web/src/app/login/page.tsx
+++ b/frontend/apps/web/src/app/login/page.tsx
@@ -25,10 +25,10 @@ export default function LoginPage() {
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState("");
 
-  const submit = async () => {
-    const trimmedEmail = email.trim();
+  const submit = async (isAuthorising: boolean = true) => {
+    const trimmedEmail = isAuthorising ? email.trim() : "";
 
-    if (!trimmedEmail.includes("@")) {
+    if (!trimmedEmail.includes("@") && isAuthorising) {
       setError("Введите корректный email.");
       return;
     }
@@ -36,7 +36,7 @@ export default function LoginPage() {
     setSubmitting(true);
     setError("");
     try {
-      await auth.login({ email: trimmedEmail, password });
+      await auth.login({ email: trimmedEmail, password, is_authorising: isAuthorising });
       router.push(next);
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : "Не удалось выполнить вход.");
@@ -60,8 +60,11 @@ export default function LoginPage() {
           onChange={(e) => setPassword(e.target.value)}
           fullWidth
         />
-        <Button variant="contained" size="large" disabled={!email || !password || submitting} onClick={submit}>
+        <Button variant="contained" size="large" disabled={!email || !password || submitting} onClick={() => submit()}>
           {submitting ? "Входим..." : "Войти"}
+        </Button>
+        <Button variant="contained" size="large" onClick={() => submit(false)}>
+          Продолжить без входа
         </Button>
         <Typography variant="body2" color="text.secondary">
           Нет аккаунта? <Link href="/register">Зарегистрироваться</Link>

--- a/services/main-pipeline/cmd/api-gateway/main.go
+++ b/services/main-pipeline/cmd/api-gateway/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/Intelligent-Smart-Home-Design-System/monorepo/services/main-pipeline/workflows"
 	"github.com/Intelligent-Smart-Home-Design-System/monorepo/shared/telemetry/go/otelsetup"
 	"github.com/Intelligent-Smart-Home-Design-System/monorepo/shared/telemetry/go/otelzerolog"
+	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
 	"github.com/lib/pq"
 	"github.com/prometheus/client_golang/prometheus"
@@ -124,7 +125,7 @@ func buildAPI(log zerolog.Logger, temporalClient client.Client, startedTotal *pr
 			AccessToken:  access,
 			RefreshToken: refresh,
 			TokenType:    "Bearer",
-			User:         &authUser{Email: normalizeEmail(req.Email), Name: req.Name},
+			User:         &authUser{Id: uuid.NewString(), Email: normalizeEmail(req.Email), Name: req.Name},
 		})
 	})
 	mux.HandleFunc("POST /auth/login", func(w http.ResponseWriter, r *http.Request) {
@@ -132,7 +133,8 @@ func buildAPI(log zerolog.Logger, temporalClient client.Client, startedTotal *pr
 		if !decodeJSON(w, r, &req) {
 			return
 		}
-		access, refresh, err := auth.login(req.Email, req.Password)
+		id := uuid.NewString()
+		access, refresh, err := auth.login(id, req.Email, req.Password, req.IsAuthorising)
 		if err != nil {
 			log.Warn().Ctx(r.Context()).Str("event", "auth.login").Str("email", normalizeEmail(req.Email)).Err(err).Msg("login rejected")
 			writeError(w, http.StatusUnauthorized, "invalid credentials")
@@ -142,7 +144,7 @@ func buildAPI(log zerolog.Logger, temporalClient client.Client, startedTotal *pr
 			AccessToken:  access,
 			RefreshToken: refresh,
 			TokenType:    "Bearer",
-			User:         &authUser{Email: normalizeEmail(req.Email)},
+			User:         &authUser{Id: id, Email: normalizeEmail(req.Email)},
 		})
 	})
 	mux.HandleFunc("POST /auth/refresh", func(w http.ResponseWriter, r *http.Request) {
@@ -164,7 +166,7 @@ func buildAPI(log zerolog.Logger, temporalClient client.Client, startedTotal *pr
 			AccessToken:  access,
 			RefreshToken: refresh,
 			TokenType:    "Bearer",
-			User:         &authUser{Email: subject},
+			User:         &authUser{Id: uuid.NewString(), Email: subject},
 		})
 	})
 	mux.HandleFunc("POST /auth/forgot-password", func(w http.ResponseWriter, r *http.Request) {
@@ -374,9 +376,10 @@ func serve(log zerolog.Logger, name string, server *http.Server) {
 }
 
 type credentialsRequest struct {
-	Email    string `json:"email"`
-	Password string `json:"password"`
-	Name     string `json:"name,omitempty"`
+	Email         string `json:"email"`
+	Password      string `json:"password"`
+	Name          string `json:"name,omitempty"`
+	IsAuthorising bool   `json:"is_authorising"`
 }
 
 type refreshRequest struct {
@@ -394,7 +397,8 @@ type resetPasswordRequest struct {
 }
 
 type authUser struct {
-	Email string `json:"email"`
+	Id    string `json:"id"`
+	Email string `json:"email,omitempty"`
 	Name  string `json:"name,omitempty"`
 }
 
@@ -458,11 +462,15 @@ func (a *authService) register(email, password string) (string, string, error) {
 	return a.issueTokens(email)
 }
 
-func (a *authService) login(email, password string) (string, string, error) {
+func (a *authService) login(id string, email, password string, isAuthorosing bool) (string, string, error) {
 	email = normalizeEmail(email)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
+
+	if !isAuthorosing {
+		return a.issueTokens(id)
+	}
 
 	user, err := a.getUser(ctx, email)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -476,7 +484,7 @@ func (a *authService) login(email, password string) (string, string, error) {
 	if subtle.ConstantTimeCompare([]byte(expected), []byte(user.PasswordHash)) != 1 {
 		return "", "", errors.New("invalid credentials")
 	}
-	return a.issueTokens(email)
+	return a.issueTokens(id)
 }
 
 // refresh проверяет refresh-токен и выпускает новую пару токенов.


### PR DESCRIPTION
Задача: добавить возможность неавторизировавшимся юзерам создавать свои планы вручную/автоподбором.

Были изменены:

- http запрс для авторизации на фронте `{ email, password } -> { email, password, is_authorising }`
- Поля хранимого юзера на фронте: email - оциональное поле, id (UUID) - обязяательное, как правило генерируется на 
 сервере при корректной авторизации.
- Endpoint логина на сервере под новый запрос
- Генерация JWT токена на сервере для аутентификации (теперь генерация не по email, а по id)
- Проверка на корректность юзера в ответе сервера. Теперь критерий не email а id 